### PR TITLE
fix: extract PrintButton into client component to fix guide page error

### DIFF
--- a/src/app/guide/PrintButton.tsx
+++ b/src/app/guide/PrintButton.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function PrintButton() {
+  return (
+    <button
+      onClick={() => window.print()}
+      className="btn-secondary text-sm no-print"
+    >
+      Print Guide
+    </button>
+  );
+}

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,4 +1,5 @@
 import AppLayout from "@/components/AppLayout";
+import PrintButton from "./PrintButton";
 
 export default function GuidePage() {
   return (
@@ -19,12 +20,7 @@ function GuideContent() {
             ABC Janitorial Services LLC · Tax Year 2025
           </p>
         </div>
-        <button
-          onClick={() => window.print()}
-          className="btn-secondary text-sm no-print"
-        >
-          Print Guide
-        </button>
+        <PrintButton />
       </div>
 
       {/* Critical Warning */}


### PR DESCRIPTION
The guide page was a Server Component with an onClick handler on a button, which is not allowed in Next.js App Router. Extracted the print button into a separate Client Component (PrintButton.tsx) with the 'use client' directive.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)