### PR TITLE
fix: remaining employee_id type error in FilingEmployeesClient

### DIFF
--- a/src/app/filing/employees/FilingEmployeesClient.tsx
+++ b/src/app/filing/employees/FilingEmployeesClient.tsx
@@ -313,7 +313,7 @@ export default function FilingEmployeesClient({
                           disabled={markingReady === emp.id}
                           className="text-xs text-green-700 hover:text-green-900 font-medium disabled:opacity-50"
                         >
-                          {markingReady === emp.employee_id ? "..." : "Mark Ready"}
+                          {markingReady === emp.id ? "..." : "Mark Ready"}
                         </button>
                       ) : (
                         <span className="text-xs text-gray-400">


### PR DESCRIPTION
Fixes the remaining TypeScript type error in `FilingEmployeesClient.tsx` line 316 where `emp.employee_id` was used instead of `emp.id` on the EmployeeStatus type.

Reference: PR #13

Generated with [Claude Code](https://claude.ai/code)