### PR TITLE
feat: WinTeam access requirements feature

### DIFF
--- a/src/app/filing/access/AccessClient.tsx
+++ b/src/app/filing/access/AccessClient.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useToast } from "@/components/Toast";
+import {
+  getFilingChecklist,
+  ROLE_METADATA,
+  type WinTeamRole,
+} from "@/lib/filing-checklist-items";
+
+interface ProgressRow {
+  item_key: string;
+  assigned_to?: string | null;
+  assigned_at?: string | null;
+  is_complete: boolean;
+}
+
+interface Props {
+  taxYear: number;
+  initialProgress: ProgressRow[];
+}
+
+const PHASE_NAMES: Record<number, string> = {
+  1: "Phase 1 — Audit Prior Year WinTeam Setup",
+  2: "Phase 2 — Fix Issues and Roll Forward",
+  3: "Phase 3 — Data Catch-Up",
+  4: "Phase 4 — Generate, Verify, and File",
+};
+
+const PERMISSION_LEVEL_LABEL: Record<string, string> = {
+  read: "Read",
+  read_write: "Read/Write",
+  admin: "Admin",
+};
+
+function RoleBadge({ role }: { role: WinTeamRole }) {
+  const meta = ROLE_METADATA[role];
+  const icon = role === "winteam_admin" ? "🔒" : role === "team_software_support" ? "📞" : "👤";
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${meta.badgeClass}`}>
+      {icon} {meta.label}
+    </span>
+  );
+}
+
+export default function AccessClient({ taxYear, initialProgress }: Props) {
+  const { showToast } = useToast();
+  const supabase = createClient();
+  const checklist = getFilingChecklist(taxYear);
+
+  // Assignments state
+  const [assignments, setAssignments] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    initialProgress.forEach((p) => {
+      if (p.assigned_to) map[p.item_key] = p.assigned_to;
+    });
+    return map;
+  });
+
+  // Pre-flight checklist state (persisted locally only — browser storage)
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [namedFields, setNamedFields] = useState<Record<string, string>>({});
+
+  const saveAssignment = useCallback(
+    async (key: string, assignedTo: string) => {
+      const progress = initialProgress.find((p) => p.item_key === key);
+      await supabase
+        .from("filing_checklist_progress")
+        .upsert(
+          {
+            tax_year: taxYear,
+            item_key: key,
+            assigned_to: assignedTo || null,
+            assigned_at: assignedTo ? new Date().toISOString() : null,
+            is_complete: progress?.is_complete ?? false,
+          },
+          { onConflict: "tax_year,item_key" }
+        );
+    },
+    [supabase, taxYear, initialProgress]
+  );
+
+  // Count tasks per role
+  const tasksByRole = checklist.reduce<Record<WinTeamRole, number>>(
+    (acc, item) => {
+      acc[item.access_required.winteam_role] = (acc[item.access_required.winteam_role] ?? 0) + 1;
+      return acc;
+    },
+    { standard_hr: 0, hr_manager: 0, winteam_admin: 0, team_software_support: 0 }
+  );
+
+  const roleOrder: WinTeamRole[] = ["standard_hr", "hr_manager", "winteam_admin", "team_software_support"];
+
+  const winteamGrantInstructions: Record<WinTeamRole, string> = {
+    standard_hr: "Grant access in WinTeam via SYS > User Setup > assign to INS Benefits by Employee and Employee Master File groups.",
+    hr_manager: "Grant access in WinTeam via SYS > User Setup > assign report permissions for INS: Employee 1095-C Report.",
+    winteam_admin: "Grant via SYS > User Setup > assign Administrator role or SYS group access.",
+    team_software_support: "Contact TEAM Software support directly to arrange assistance.",
+  };
+
+  const checkedCount = Object.values(checked).filter(Boolean).length;
+
+  return (
+    <div className="space-y-8 print:space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between print:hidden">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <a href="/filing" className="text-navy-600 hover:text-navy-800 text-sm">
+              ← Filing Assistant
+            </a>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">Access Plan</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Review who needs what WinTeam access before starting the {taxYear} filing process.
+          </p>
+        </div>
+        <button
+          onClick={() => window.print()}
+          className="btn-secondary text-sm print:hidden"
+        >
+          🖨 Print Access Plan
+        </button>
+      </div>
+
+      {/* Print header */}
+      <div className="hidden print:block mb-4">
+        <h1 className="text-xl font-bold text-gray-900">Access Plan — {taxYear} 1095-C Filing</h1>
+        <p className="text-sm text-gray-500">RBM Services Inc.</p>
+      </div>
+
+      {/* A. Header Summary — Role Cards */}
+      <section>
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">WinTeam Access Roles</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {roleOrder.map((role) => {
+            const meta = ROLE_METADATA[role];
+            const count = tasksByRole[role] ?? 0;
+            const icon = role === "winteam_admin" ? "🔒" : role === "team_software_support" ? "📞" : "👤";
+            return (
+              <div
+                key={role}
+                className={`rounded-xl border-2 p-4 ${meta.borderClass} bg-white`}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-lg">{icon}</span>
+                  <span className={`text-sm font-bold ${meta.textClass}`}>{meta.label}</span>
+                </div>
+                <p className="text-2xl font-bold text-gray-900 mb-1">{count}</p>
+                <p className="text-xs text-gray-500 mb-3">tasks</p>
+                <p className="text-xs text-gray-600 leading-relaxed">{meta.description}</p>
+                <div className={`mt-3 pt-3 border-t ${meta.borderClass}`}>
+                  <p className="text-xs text-gray-500 italic leading-relaxed">
+                    {winteamGrantInstructions[role]}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* B. Access by Phase Tables */}
+      <section>
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">Access Requirements by Phase</h2>
+        <div className="space-y-6">
+          {([1, 2, 3, 4] as const).map((phase) => {
+            const phaseItems = checklist.filter((i) => i.phase === phase);
+            return (
+              <div key={phase} className="card overflow-hidden p-0">
+                <div className="px-4 py-3 bg-gray-50 border-b border-gray-200">
+                  <h3 className="font-semibold text-gray-900 text-sm">{PHASE_NAMES[phase]}</h3>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-gray-200 bg-white">
+                        <th className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500 uppercase tracking-wide w-2/5">Task</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Who Can Do It</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">WinTeam Modules</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500 uppercase tracking-wide w-24">Delegate?</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500 uppercase tracking-wide w-36 print:hidden">Assign To</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {phaseItems.map((item) => {
+                        const access = item.access_required;
+                        return (
+                          <tr key={item.key} className="hover:bg-gray-50">
+                            <td className="px-4 py-3">
+                              <p className="text-xs font-medium text-gray-900 leading-snug">{item.label}</p>
+                              {assignments[item.key] && (
+                                <p className="text-xs text-gray-400 mt-0.5">→ {assignments[item.key]}</p>
+                              )}
+                            </td>
+                            <td className="px-4 py-3">
+                              <RoleBadge role={access.winteam_role} />
+                            </td>
+                            <td className="px-4 py-3">
+                              {access.modules.length === 0 ? (
+                                <span className="text-xs text-gray-400 italic">None (app only)</span>
+                              ) : (
+                                <div className="space-y-1">
+                                  {access.modules.map((m, idx) => (
+                                    <div key={idx} className="text-xs text-gray-700">
+                                      <span className="font-mono">{m.module}</span>
+                                      <span className="text-gray-400 ml-1">({PERMISSION_LEVEL_LABEL[m.permission_level]})</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </td>
+                            <td className="px-4 py-3">
+                              {access.can_delegate ? (
+                                <span className="text-xs text-green-700 font-medium">✓ Yes</span>
+                              ) : (
+                                <span className="text-xs text-red-600 font-medium">✗ No</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 print:hidden">
+                              <input
+                                type="text"
+                                placeholder="Name..."
+                                value={assignments[item.key] ?? ""}
+                                onChange={(e) =>
+                                  setAssignments((prev) => ({ ...prev, [item.key]: e.target.value }))
+                                }
+                                onBlur={(e) => saveAssignment(item.key, e.target.value)}
+                                className="w-full text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-navy-500"
+                              />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* C. Permissions Pre-Flight Checklist */}
+      <section>
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">Pre-Flight Permissions Checklist</h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Before you begin, confirm these people have the right WinTeam access. Check each item off as you verify it.
+          {checkedCount > 0 && (
+            <span className="ml-2 text-green-700 font-medium">{checkedCount} / 9 verified</span>
+          )}
+        </p>
+
+        <div className="card space-y-6">
+          {/* WinTeam Admin */}
+          <div>
+            <h3 className="text-sm font-semibold text-red-700 mb-3 flex items-center gap-1.5">
+              🔒 WinTeam Administrator
+            </h3>
+            <div className="space-y-3 pl-2">
+              <ChecklistRow
+                id="admin_identified"
+                checked={!!checked["admin_identified"]}
+                onToggle={() => setChecked((p) => ({ ...p, admin_identified: !p.admin_identified }))}
+              >
+                <span>WinTeam Administrator identified:</span>
+                <input
+                  type="text"
+                  placeholder="Name"
+                  value={namedFields["admin_name"] ?? ""}
+                  onChange={(e) => setNamedFields((p) => ({ ...p, admin_name: e.target.value }))}
+                  className="ml-2 text-xs border-b border-gray-300 focus:border-red-400 focus:outline-none bg-transparent w-40"
+                />
+                <span className="text-xs text-gray-400 ml-1">(person who will do admin-level steps)</span>
+              </ChecklistRow>
+
+              <ChecklistRow
+                id="admin_access"
+                checked={!!checked["admin_access"]}
+                onToggle={() => setChecked((p) => ({ ...p, admin_access: !p.admin_access }))}
+              >
+                <span>WinTeam Administrator has access to:</span>
+                <ul className="mt-1 pl-4 text-xs text-gray-600 space-y-0.5 list-disc">
+                  <li>SYS: Company Setup</li>
+                  <li>INS: Benefit Setup</li>
+                  <li>INS: Eligibility Setup</li>
+                  <li>INS: Eligibility Testing Wizard</li>
+                  <li>INS: Employee 1095-C Report (Electronic File)</li>
+                </ul>
+              </ChecklistRow>
+            </div>
+          </div>
+
+          {/* HR Manager */}
+          <div className="border-t border-gray-100 pt-5">
+            <h3 className="text-sm font-semibold text-purple-700 mb-3 flex items-center gap-1.5">
+              👤 HR Manager / Power User
+            </h3>
+            <div className="space-y-3 pl-2">
+              <ChecklistRow
+                id="manager_identified"
+                checked={!!checked["manager_identified"]}
+                onToggle={() => setChecked((p) => ({ ...p, manager_identified: !p.manager_identified }))}
+              >
+                <span>HR Manager identified:</span>
+                <input
+                  type="text"
+                  placeholder="Name"
+                  value={namedFields["manager_name"] ?? ""}
+                  onChange={(e) => setNamedFields((p) => ({ ...p, manager_name: e.target.value }))}
+                  className="ml-2 text-xs border-b border-gray-300 focus:border-purple-400 focus:outline-none bg-transparent w-40"
+                />
+                <span className="text-xs text-gray-400 ml-1">(person who will run reports and manage packages)</span>
+              </ChecklistRow>
+
+              <ChecklistRow
+                id="manager_access"
+                checked={!!checked["manager_access"]}
+                onToggle={() => setChecked((p) => ({ ...p, manager_access: !p.manager_access }))}
+              >
+                <span>HR Manager has access to:</span>
+                <ul className="mt-1 pl-4 text-xs text-gray-600 space-y-0.5 list-disc">
+                  <li>INS: Employee 1095-C Report (Preview/Print)</li>
+                  <li>INS: Benefits by Employee (Read/Write)</li>
+                  <li>Employee Master File (Read/Write)</li>
+                </ul>
+              </ChecklistRow>
+            </div>
+          </div>
+
+          {/* HR Staff */}
+          <div className="border-t border-gray-100 pt-5">
+            <h3 className="text-sm font-semibold text-blue-700 mb-3 flex items-center gap-1.5">
+              👤 Standard HR Staff
+            </h3>
+            <div className="space-y-3 pl-2">
+              <ChecklistRow
+                id="staff_identified"
+                checked={!!checked["staff_identified"]}
+                onToggle={() => setChecked((p) => ({ ...p, staff_identified: !p.staff_identified }))}
+              >
+                <span>HR Staff identified for data entry:</span>
+                <input
+                  type="text"
+                  placeholder="Names (comma-separated)"
+                  value={namedFields["staff_names"] ?? ""}
+                  onChange={(e) => setNamedFields((p) => ({ ...p, staff_names: e.target.value }))}
+                  className="ml-2 text-xs border-b border-gray-300 focus:border-blue-400 focus:outline-none bg-transparent w-56"
+                />
+              </ChecklistRow>
+
+              <ChecklistRow
+                id="staff_access"
+                checked={!!checked["staff_access"]}
+                onToggle={() => setChecked((p) => ({ ...p, staff_access: !p.staff_access }))}
+              >
+                <span>HR Staff have access to:</span>
+                <ul className="mt-1 pl-4 text-xs text-gray-600 space-y-0.5 list-disc">
+                  <li>INS: Benefits by Employee (Read/Write)</li>
+                  <li>Employee Master File (Read/Write)</li>
+                </ul>
+              </ChecklistRow>
+            </div>
+          </div>
+
+          {/* Credentials */}
+          <div className="border-t border-gray-100 pt-5">
+            <h3 className="text-sm font-semibold text-gray-700 mb-3">IRS Filing Credentials</h3>
+            <div className="space-y-3 pl-2">
+              <ChecklistRow
+                id="tcc_located"
+                checked={!!checked["tcc_located"]}
+                onToggle={() => setChecked((p) => ({ ...p, tcc_located: !p.tcc_located }))}
+              >
+                <div>
+                  <p>TCC (Transmitter Control Code) located</p>
+                  <div className="flex flex-wrap gap-4 mt-1">
+                    <span className="text-xs text-gray-500">
+                      Stored at:{" "}
+                      <input
+                        type="text"
+                        placeholder="Location"
+                        value={namedFields["tcc_location"] ?? ""}
+                        onChange={(e) => setNamedFields((p) => ({ ...p, tcc_location: e.target.value }))}
+                        className="text-xs border-b border-gray-300 focus:border-gray-500 focus:outline-none bg-transparent w-32"
+                      />
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      Held by:{" "}
+                      <input
+                        type="text"
+                        placeholder="Name"
+                        value={namedFields["tcc_holder"] ?? ""}
+                        onChange={(e) => setNamedFields((p) => ({ ...p, tcc_holder: e.target.value }))}
+                        className="text-xs border-b border-gray-300 focus:border-gray-500 focus:outline-none bg-transparent w-32"
+                      />
+                    </span>
+                  </div>
+                </div>
+              </ChecklistRow>
+
+              <ChecklistRow
+                id="fire_creds"
+                checked={!!checked["fire_creds"]}
+                onToggle={() => setChecked((p) => ({ ...p, fire_creds: !p.fire_creds }))}
+              >
+                <div>
+                  <p>FIRE system credentials (username/password) located</p>
+                  <div className="mt-1">
+                    <span className="text-xs text-gray-500">
+                      Held by:{" "}
+                      <input
+                        type="text"
+                        placeholder="Name"
+                        value={namedFields["fire_holder"] ?? ""}
+                        onChange={(e) => setNamedFields((p) => ({ ...p, fire_holder: e.target.value }))}
+                        className="text-xs border-b border-gray-300 focus:border-gray-500 focus:outline-none bg-transparent w-32"
+                      />
+                    </span>
+                  </div>
+                </div>
+              </ChecklistRow>
+
+              <ChecklistRow
+                id="team_portal_creds"
+                checked={!!checked["team_portal_creds"]}
+                onToggle={() => setChecked((p) => ({ ...p, team_portal_creds: !p.team_portal_creds }))}
+              >
+                <div>
+                  <p>TEAM Software e-file portal credentials <span className="text-gray-400">(if using their service)</span></p>
+                  <div className="mt-1">
+                    <span className="text-xs text-gray-500">
+                      Held by:{" "}
+                      <input
+                        type="text"
+                        placeholder="Name or N/A"
+                        value={namedFields["team_portal_holder"] ?? ""}
+                        onChange={(e) => setNamedFields((p) => ({ ...p, team_portal_holder: e.target.value }))}
+                        className="text-xs border-b border-gray-300 focus:border-gray-500 focus:outline-none bg-transparent w-32"
+                      />
+                    </span>
+                  </div>
+                </div>
+              </ChecklistRow>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Print button at bottom */}
+      <div className="print:hidden">
+        <button
+          onClick={() => window.print()}
+          className="btn-primary"
+        >
+          🖨 Print Access Plan
+        </button>
+        <p className="text-xs text-gray-400 mt-2">
+          Print this page and distribute to your team before starting Phase 1.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ChecklistRow({
+  id,
+  checked,
+  onToggle,
+  children,
+}: {
+  id: string;
+  checked: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <input
+        type="checkbox"
+        id={id}
+        checked={checked}
+        onChange={onToggle}
+        className="mt-0.5 w-4 h-4 rounded border-gray-300 text-navy-600 focus:ring-navy-500 flex-shrink-0 cursor-pointer"
+      />
+      <label
+        htmlFor={id}
+        className={`text-sm cursor-pointer leading-snug ${checked ? "text-gray-400 line-through" : "text-gray-700"}`}
+      >
+        {children}
+      </label>
+    </div>
+  );
+}

--- a/src/app/filing/access/page.tsx
+++ b/src/app/filing/access/page.tsx
@@ -1,0 +1,26 @@
+import { createClient } from "@/lib/supabase/server";
+import AppLayout from "@/components/AppLayout";
+import AccessClient from "./AccessClient";
+
+interface Props {
+  searchParams: Promise<{ year?: string }>;
+}
+
+export default async function AccessPage({ searchParams }: Props) {
+  const { year: yearParam } = await searchParams;
+  const taxYear = yearParam ? Number(yearParam) : 2025;
+
+  const supabase = await createClient();
+
+  // Load checklist progress (for assigned_to data)
+  const { data: progress } = await supabase
+    .from("filing_checklist_progress")
+    .select("*")
+    .eq("tax_year", taxYear);
+
+  return (
+    <AppLayout>
+      <AccessClient taxYear={taxYear} initialProgress={progress ?? []} />
+    </AppLayout>
+  );
+}

--- a/src/app/filing/phase/[number]/PhaseClient.tsx
+++ b/src/app/filing/phase/[number]/PhaseClient.tsx
@@ -9,6 +9,7 @@ import {
   getFilingChecklist,
   getGateItems,
   PHASE_METADATA,
+  ROLE_METADATA,
   type FilingChecklistItem,
 } from "@/lib/filing-checklist-items";
 
@@ -27,6 +28,7 @@ interface ProgressRow {
   is_complete: boolean;
   finding?: string | null;
   action_taken?: string | null;
+  assigned_to?: string | null;
 }
 
 interface Props {
@@ -117,6 +119,14 @@ export default function PhaseClient({
     return map;
   });
 
+  const [assignments, setAssignments] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    initialProgress.forEach((p) => {
+      if (p.assigned_to) map[p.item_key] = p.assigned_to;
+    });
+    return map;
+  });
+
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [walkthroughItem, setWalkthroughItem] = useState<FilingChecklistItem | null>(null);
   const [issueDrawerOpen, setIssueDrawerOpen] = useState(false);
@@ -174,6 +184,24 @@ export default function PhaseClient({
         .from("filing_checklist_progress")
         .upsert(
           { tax_year: taxYear, item_key: key, finding, is_complete: completed.has(key) },
+          { onConflict: "tax_year,item_key" }
+        );
+    },
+    [supabase, taxYear, completed]
+  );
+
+  const saveAssignment = useCallback(
+    async (key: string, assignedTo: string) => {
+      await supabase
+        .from("filing_checklist_progress")
+        .upsert(
+          {
+            tax_year: taxYear,
+            item_key: key,
+            assigned_to: assignedTo || null,
+            assigned_at: assignedTo ? new Date().toISOString() : null,
+            is_complete: completed.has(key),
+          },
           { onConflict: "tax_year,item_key" }
         );
     },
@@ -403,6 +431,25 @@ export default function PhaseClient({
                                 {item.winteamPath}
                               </span>
                             )}
+                            {/* Access badge */}
+                            {(() => {
+                              const access = item.access_required;
+                              const roleMeta = ROLE_METADATA[access.winteam_role];
+                              const icon = access.winteam_role === 'winteam_admin' ? '🔒' : access.winteam_role === 'team_software_support' ? '📞' : '👤';
+                              return (
+                                <span
+                                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${roleMeta.badgeClass}`}
+                                  title={`${roleMeta.label}${access.delegation_notes ? ` — ${access.delegation_notes}` : ''}`}
+                                >
+                                  {icon} {roleMeta.label}
+                                </span>
+                              );
+                            })()}
+                            {item.access_required.can_delegate && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 border border-gray-200">
+                                Delegatable
+                              </span>
+                            )}
                           </div>
 
                           {/* Walk me through this button */}
@@ -458,6 +505,24 @@ export default function PhaseClient({
                               Log Issue
                             </button>
                           </div>
+
+                          {/* Assign to */}
+                          <div className="flex gap-2 items-center mt-1.5">
+                            <label className="text-xs text-gray-500 whitespace-nowrap">Assign to:</label>
+                            <input
+                              type="text"
+                              placeholder="Team member name"
+                              value={assignments[item.key] ?? ""}
+                              onChange={(e) =>
+                                setAssignments((prev) => ({ ...prev, [item.key]: e.target.value }))
+                              }
+                              onBlur={(e) => saveAssignment(item.key, e.target.value)}
+                              className="flex-1 text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-navy-500 bg-white"
+                            />
+                          </div>
+                          {assignments[item.key] && (
+                            <p className="text-xs text-gray-400 mt-0.5">Assigned to: {assignments[item.key]}</p>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -21,6 +21,7 @@ function deadlineBadgeClass(days: number): string {
 
 const FILING_NAV_ITEMS = [
   { href: "/filing", label: "2025 Filing", showDeadline: true },
+  { href: "/filing/access", label: "Access Plan" },
   { href: "/checklist", label: "Audit Checklist" },
   { href: "/wizard", label: "Code Wizard" },
   { href: "/tracker", label: "Employee Tracker" },
@@ -61,7 +62,7 @@ export default function Navigation({ userEmail, isAdmin }: NavigationProps) {
       return pathname === "/payroll" || pathname.startsWith("/payroll/employees");
     }
     if (href === "/filing") {
-      return pathname === "/filing" || pathname.startsWith("/filing/");
+      return pathname === "/filing" || (pathname.startsWith("/filing/") && !pathname.startsWith("/filing/access"));
     }
     return pathname.startsWith(href);
   }

--- a/src/components/WalkthroughOverlay.tsx
+++ b/src/components/WalkthroughOverlay.tsx
@@ -95,6 +95,59 @@ export default function WalkthroughOverlay({
 
         {/* Scrollable body */}
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {/* Access needed banner */}
+          {(() => {
+            const access = item.access_required;
+            const role = access.winteam_role;
+            if (role === 'winteam_admin') {
+              return (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                  <div className="flex items-start gap-2">
+                    <span className="text-base flex-shrink-0">🔒</span>
+                    <div>
+                      <p className="text-sm font-semibold text-red-800">This step requires WinTeam Administrator access</p>
+                      <p className="text-xs text-red-700 mt-1 leading-relaxed">
+                        Make sure your WinTeam Admin is available before starting. They will need to be at the computer or logged in remotely.
+                        {access.delegation_notes && <span> {access.delegation_notes}</span>}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+            if (role === 'hr_manager') {
+              return (
+                <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+                  <div className="flex items-start gap-2">
+                    <span className="text-base flex-shrink-0">👤</span>
+                    <div>
+                      <p className="text-sm font-semibold text-purple-800">This step requires HR Manager access in WinTeam</p>
+                      {access.delegation_notes && (
+                        <p className="text-xs text-purple-700 mt-1 leading-relaxed">{access.delegation_notes}</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+            if (role === 'standard_hr') {
+              return (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                  <div className="flex items-start gap-2">
+                    <span className="text-base flex-shrink-0">👤</span>
+                    <div>
+                      <p className="text-sm font-semibold text-blue-800">Any HR staff member can do this step</p>
+                      {access.delegation_notes && (
+                        <p className="text-xs text-blue-700 mt-1 leading-relaxed">{access.delegation_notes}</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+            return null;
+          })()}
+
           {/* Overview */}
           <div className="bg-blue-50 border border-blue-100 rounded-lg p-4">
             <p className="text-sm text-blue-900 leading-relaxed">{walkthrough.overview}</p>

--- a/src/lib/filing-checklist-items.ts
+++ b/src/lib/filing-checklist-items.ts
@@ -16,6 +16,57 @@ export type Walkthrough = {
   estimated_minutes: number
 }
 
+export type WinTeamAccess = {
+  module: string
+  permission_level: 'read' | 'read_write' | 'admin'
+  specific_permission?: string
+  notes?: string
+}
+
+export type WinTeamRole = 'standard_hr' | 'hr_manager' | 'winteam_admin' | 'team_software_support'
+
+export type AccessRequired = {
+  winteam_role: WinTeamRole
+  modules: WinTeamAccess[]
+  can_delegate: boolean
+  delegation_notes?: string
+}
+
+export const ROLE_METADATA: Record<WinTeamRole, { label: string; description: string; color: string; badgeClass: string; textClass: string; borderClass: string }> = {
+  standard_hr: {
+    label: 'Standard HR User',
+    description: 'Basic HR staff with access to view and edit employee records, enter hours, and manage benefit enrollments in INS: Benefits by Employee. Cannot access SYS: Company Setup or INS: Benefit Setup.',
+    color: 'blue',
+    badgeClass: 'bg-blue-100 text-blue-800 border border-blue-200',
+    textClass: 'text-blue-700',
+    borderClass: 'border-blue-200',
+  },
+  hr_manager: {
+    label: 'HR Manager / Power User',
+    description: 'HR staff with elevated access to run 1095-C reports, execute the Eligibility Testing Wizard, view and edit benefit packages, and access most INS screens. Cannot access SYS.',
+    color: 'purple',
+    badgeClass: 'bg-purple-100 text-purple-800 border border-purple-200',
+    textClass: 'text-purple-700',
+    borderClass: 'border-purple-200',
+  },
+  winteam_admin: {
+    label: 'WinTeam Administrator',
+    description: 'Full system access including SYS: Company Setup, INS: Benefit Setup, and all configuration screens. Typically the person who manages your WinTeam system. There may only be one or two people with this role.',
+    color: 'red',
+    badgeClass: 'bg-red-100 text-red-800 border border-red-200',
+    textClass: 'text-red-700',
+    borderClass: 'border-red-200',
+  },
+  team_software_support: {
+    label: 'TEAM Software Support',
+    description: 'Tasks that require involvement from TEAM Software directly — either because they require backend access or because the risk of error is high enough that professional support is recommended.',
+    color: 'gray',
+    badgeClass: 'bg-gray-200 text-gray-800 border border-gray-300',
+    textClass: 'text-gray-700',
+    borderClass: 'border-gray-300',
+  },
+}
+
 export type FilingChecklistItem = {
   key: string
   phase: 1 | 2 | 3 | 4
@@ -27,12 +78,380 @@ export type FilingChecklistItem = {
   isGate: boolean
   order: number
   walkthrough?: Walkthrough
+  access_required: AccessRequired
+}
+
+// Access requirements for each checklist item
+const ACCESS_REQUIREMENTS: Record<string, AccessRequired> = {
+  // ── Phase 1: SYS Company Setup ─────────────────────────────────────────────
+  audit_sys_aca_enabled: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'SYS: Company Setup', permission_level: 'admin', notes: 'SYS access required. Standard HR and HR Manager roles cannot access Company Setup.' }],
+    can_delegate: false,
+    delegation_notes: 'Must be performed by your WinTeam Administrator. If you are not sure who that is, contact TEAM Software support.',
+  },
+  audit_sys_ein: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'SYS: Company Setup', permission_level: 'admin' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only. Have your accountant or payroll provider confirm the correct EIN before making any changes.',
+  },
+  audit_sys_phone: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'SYS: Company Setup', permission_level: 'admin' }],
+    can_delegate: false,
+  },
+  // ── Phase 1: INS Eligibility Setup ─────────────────────────────────────────
+  audit_ins_aca_compliant: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Eligibility Setup', permission_level: 'admin', notes: 'Eligibility Setup is typically restricted to WinTeam Administrators. Some organizations grant HR Managers read access but not write access.' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator must make any changes. An HR Manager with read access can verify the setting but cannot fix it if it is wrong.',
+  },
+  audit_ins_plan_start_month: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Eligibility Setup', permission_level: 'admin' }],
+    can_delegate: false,
+  },
+  // ── Phase 1: INS Benefit Setup (all plan config items) ─────────────────────
+  audit_plan1_aca: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit', notes: 'Benefit Setup is a configuration screen restricted to WinTeam Administrators. Changes here affect all employees assigned to these plans.' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only. These are system configuration changes — not employee data entry. One wrong checkbox here affects every 1095-C you generate.',
+  },
+  audit_plan1_self_insured: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only. These are system configuration changes.',
+  },
+  audit_plan1_min_value: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan1_premium: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan1_options: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan2_aca: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit', notes: 'Benefit Setup is a configuration screen restricted to WinTeam Administrators.' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only. These are system configuration changes.',
+  },
+  audit_plan2_self_insured: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan2_min_value: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan2_options: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan3_aca: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit', notes: 'Benefit Setup is a configuration screen restricted to WinTeam Administrators.' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan3_self_insured: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan3_min_value: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  audit_plan3_options: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', specific_permission: 'INS: Benefit Setup - Edit' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  // ── Phase 1: Benefit Package Verification ──────────────────────────────────
+  audit_packages_all_three: {
+    winteam_role: 'hr_manager',
+    modules: [
+      { module: 'INS: Benefits by Employee', permission_level: 'read_write', notes: 'Read access needed to verify packages. Write access needed if packages must be corrected.' },
+      { module: 'INS: Benefit Setup', permission_level: 'admin', notes: 'If packages need to be updated to include all three plans, the package template itself must be edited by a WinTeam Administrator.' },
+    ],
+    can_delegate: true,
+    delegation_notes: 'An HR Manager can verify whether packages are correct. If corrections are needed, a WinTeam Administrator must make them. Plan to have both people available for this step.',
+  },
+  // ── Phase 1: Preview Report ─────────────────────────────────────────────────
+  audit_preview_line14: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run', notes: 'Running the 1095-C report typically requires HR Manager level access or a specific report permission granted by the WinTeam Administrator.' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff member with 1095-C Report access can run this. If no one has this access, contact your WinTeam Administrator to grant it before starting Phase 1.',
+  },
+  audit_part3_populated: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff member with 1095-C Report access can run this.',
+  },
+  audit_line15_consistent: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff member with 1095-C Report access can run this.',
+  },
+  // ── Phase 2 ─────────────────────────────────────────────────────────────────
+  rollforward_blocking_resolved: {
+    winteam_role: 'winteam_admin',
+    modules: [],
+    can_delegate: false,
+    delegation_notes: 'Resolution of blocking issues requires whoever has the WinTeam access level that corresponds to the issue category. Most blocking issues from Phase 1 will require WinTeam Administrator access.',
+  },
+  rollforward_tax_year: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', notes: 'The tax year is set at report run time, not in a settings screen. HR Manager access to the report is sufficient.' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with 1095-C Report access can do this.',
+  },
+  rollforward_affordability: {
+    winteam_role: 'standard_hr',
+    modules: [],
+    can_delegate: true,
+    delegation_notes: 'This setting is updated in this app on the Settings page. Any admin user of this app can make this change. No WinTeam access required for this specific step.',
+  },
+  rollforward_fpl: {
+    winteam_role: 'standard_hr',
+    modules: [],
+    can_delegate: true,
+    delegation_notes: 'This setting is updated in this app on the Settings page. Any admin user of this app can make this change. No WinTeam access required for this specific step.',
+  },
+  rollforward_plan1_premium: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefit Setup', permission_level: 'admin', notes: 'If the MEC premium changed for this year, it must also be updated in WinTeam INS: Benefit Setup Pricing tab — not just in this app. That part requires a WinTeam Administrator.' }],
+    can_delegate: true,
+    delegation_notes: 'App settings changes can be done by any admin user of this app. The WinTeam Benefit Setup update requires a WinTeam Administrator.',
+  },
+  rollforward_eligibility_wizard: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Eligibility Testing Wizard', permission_level: 'admin', specific_permission: 'INS: Eligibility Testing Wizard - Execute', notes: 'The Eligibility Testing Wizard re-evaluates and reassigns benefit eligibility for your entire workforce. It requires Administrator access and should be run with care.' }],
+    can_delegate: false,
+    delegation_notes: 'This must be run by your WinTeam Administrator. Consider having TEAM Software support on standby the first time you run this for a new year. Recommended to run during off-hours.',
+  },
+  rollforward_benefit_packages: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write', notes: 'Assigning packages to employees requires write access to Benefits by Employee.' }],
+    can_delegate: true,
+    delegation_notes: 'HR Manager or Standard HR with write access to INS: Benefits by Employee can do this. This is the most time-intensive step in Phase 2 — consider assigning it to multiple HR staff members splitting the employee list.',
+  },
+  rollforward_stability_dates: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'HR Manager or Standard HR with Benefits by Employee write access. Can be split across multiple staff members.',
+  },
+  // ── Phase 3 ─────────────────────────────────────────────────────────────────
+  data_all_ft_employees: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'Employee Master File', permission_level: 'read_write', notes: 'Write access is needed to add any missing employee records.' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with Employee Master File write access can do this.',
+  },
+  data_valid_ssn: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'Employee Master File', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with Employee Master File write access can do this. Consider assigning one person to pull a list of all employees missing SSN and contact them directly.',
+  },
+  data_dob: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'Employee Master File', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with Employee Master File write access can do this.',
+  },
+  data_plan1_enrollments: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write', notes: 'Entering benefit elections is standard HR data entry. Standard HR users with write access to Benefits by Employee can complete this.' }],
+    can_delegate: true,
+    delegation_notes: 'This is the most delegatable task in the entire process. Any HR staff member with INS: Benefits by Employee write access can enter elections. Consider splitting the employee list across your whole HR team.',
+  },
+  data_plan2_enrollments: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write', notes: 'Entering benefit elections is standard HR data entry.' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff member with INS: Benefits by Employee write access can enter elections.',
+  },
+  data_plan3_enrollments: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff member with INS: Benefits by Employee write access can enter elections.',
+  },
+  data_declined_packages: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff member with INS: Benefits by Employee write access can complete this.',
+  },
+  data_spouse_ssn: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write', notes: 'Dependent data is entered on the Covered Individuals tab within Benefits by Employee.' }],
+    can_delegate: true,
+    delegation_notes: 'Standard HR with Benefits by Employee write access. Collecting missing SSNs from employees may require reaching out directly by phone or email — build time for that into your schedule.',
+  },
+  data_dependent_dob: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write', notes: 'Dependent data is entered on the Covered Individuals tab within Benefits by Employee.' }],
+    can_delegate: true,
+    delegation_notes: 'Standard HR with Benefits by Employee write access.',
+  },
+  data_adult_ssn: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'Standard HR with Benefits by Employee write access.',
+  },
+  data_coverage_months: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'INS: Benefits by Employee', permission_level: 'read_write' }],
+    can_delegate: true,
+    delegation_notes: 'Standard HR with Benefits by Employee write access.',
+  },
+  data_variable_hour: {
+    winteam_role: 'hr_manager',
+    modules: [
+      { module: 'INS: Benefits by Employee', permission_level: 'read_write' },
+      { module: 'Eligibility Board (this app)', permission_level: 'read_write', notes: 'Check the Eligibility Board in this app first to see which employees need attention, then make changes in WinTeam.' },
+    ],
+    can_delegate: true,
+  },
+  data_terminations: {
+    winteam_role: 'standard_hr',
+    modules: [
+      { module: 'Employee Master File', permission_level: 'read_write' },
+      { module: 'INS: Benefits by Employee', permission_level: 'read_write' },
+    ],
+    can_delegate: true,
+  },
+  data_new_hires: {
+    winteam_role: 'standard_hr',
+    modules: [
+      { module: 'Employee Master File', permission_level: 'read_write' },
+      { module: 'INS: Benefits by Employee', permission_level: 'read_write' },
+    ],
+    can_delegate: true,
+  },
+  data_tracker_ready: {
+    winteam_role: 'standard_hr',
+    modules: [{ module: 'Employee Tracker (this app)', permission_level: 'read', notes: 'This step is completed entirely in this app — no WinTeam access required. Review the tracker and fix any flagged issues in WinTeam before marking this complete.' }],
+    can_delegate: true,
+  },
+  // ── Phase 4 ─────────────────────────────────────────────────────────────────
+  file_preview_all: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with 1095-C Report access can run the test report. Spot-checking the output can be done by anyone who understands what the codes should look like — use the Code Wizard in this app to verify codes if unsure.',
+  },
+  file_spot_plan1: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Spot-checking can be done by anyone who understands what the codes should look like — use the Code Wizard in this app to verify codes if unsure.',
+  },
+  file_spot_plan2: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Spot-checking can be done by anyone who understands what the codes should look like.',
+  },
+  file_spot_plan3: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Spot-checking can be done by anyone who understands what the codes should look like.',
+  },
+  file_spot_declined: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Spot-checking can be done by anyone who understands what the codes should look like.',
+  },
+  file_line15_consistent: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with 1095-C Report access can run the report.',
+  },
+  file_count_matches: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with 1095-C Report access can run the report.',
+  },
+  file_fix_rerun: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'read_write', specific_permission: 'INS: 1095-C Report - Run' }],
+    can_delegate: true,
+    delegation_notes: 'Any HR staff with 1095-C Report access can run the report. Spot-checking can be done by anyone who understands what the codes should look like.',
+  },
+  file_generate_1095c: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'admin', specific_permission: 'INS: 1095-C Electronic File - Generate', notes: 'Generating the electronic file and transmitter information requires Administrator access. This is the step that creates the actual file submitted to the IRS.' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only. Do not rush this step. Verify the transmitter information window carefully — your TCC and EIN must be exact.',
+  },
+  file_generate_1094c: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'INS: Employee 1095-C Report', permission_level: 'admin', specific_permission: 'INS: 1095-C Electronic File - Generate', notes: 'Generating the transmitter file requires Administrator access.' }],
+    can_delegate: false,
+    delegation_notes: 'WinTeam Administrator only.',
+  },
+  file_submit: {
+    winteam_role: 'winteam_admin',
+    modules: [{ module: 'IRS FIRE System or TEAM Software e-file portal', permission_level: 'admin', notes: 'Submitting through FIRE requires your TCC. Submitting through TEAM Software requires your TEAM Software portal credentials.' }],
+    can_delegate: false,
+    delegation_notes: 'Must be performed by whoever holds your TCC credentials. If you do not know who that is or where the TCC is stored, find out immediately — you cannot file without it.',
+  },
+  file_acknowledgement: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'IRS FIRE System', permission_level: 'read', notes: 'Checking acknowledgement status requires logging into FIRE with your TCC credentials.' }],
+    can_delegate: true,
+  },
+  file_save_copies: {
+    winteam_role: 'hr_manager',
+    modules: [{ module: 'IRS FIRE System', permission_level: 'read', notes: 'Download and save the acknowledgement file from FIRE.' }],
+    can_delegate: true,
+  },
 }
 
 export function getFilingChecklist(taxYear: number): FilingChecklistItem[] {
   const priorYear = taxYear - 1
 
-  const items: FilingChecklistItem[] = [
+  // Intermediate type without fields populated at map time
+  type ItemDef = Omit<FilingChecklistItem, 'access_required' | 'walkthrough'>
+
+  const items: ItemDef[] = [
     // ============================================================
     // PHASE 1 — Audit [priorYear] WinTeam Setup (22 items, all gated)
     // ============================================================
@@ -708,6 +1127,11 @@ export function getFilingChecklist(taxYear: number): FilingChecklistItem[] {
   return items.map((item) => ({
     ...item,
     walkthrough: WALKTHROUGHS[item.key],
+    access_required: ACCESS_REQUIREMENTS[item.key] ?? {
+      winteam_role: 'hr_manager' as WinTeamRole,
+      modules: [],
+      can_delegate: true,
+    },
   }))
 }
 

--- a/supabase/access_migration.sql
+++ b/supabase/access_migration.sql
@@ -1,0 +1,9 @@
+-- ============================================================
+-- Access Plan Migration
+-- Run this in the Supabase SQL editor AFTER filing_assistant.sql
+-- Adds task assignment fields to filing_checklist_progress
+-- ============================================================
+
+alter table filing_checklist_progress
+  add column if not exists assigned_to text,
+  add column if not exists assigned_at timestamptz;


### PR DESCRIPTION
Implements the full WinTeam access requirements feature from issue #17.

Adds access/permission information to the filing assistant so admins can plan who will do each task and what system access they need before starting.

**Note:** Run `supabase/access_migration.sql` in Supabase after merging.

Closes #17

Generated with [Claude Code](https://claude.ai/code)