### PR TITLE
fix: remove all hardcoded years — fully year-agnostic filing assistant

### DIFF
--- a/src/app/checklist/page.tsx
+++ b/src/app/checklist/page.tsx
@@ -6,18 +6,20 @@ export default async function ChecklistPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
-  // Load user's progress
-  const { data: progress } = await supabase
-    .from("audit_checklist_progress")
-    .select("*")
-    .eq("user_id", user!.id)
-    .eq("tax_year", 2025);
-
   // Load settings for tax year display
   const { data: settings } = await supabase
     .from("app_settings")
     .select("tax_year, company_name")
     .single();
+
+  const taxYear = settings?.tax_year ?? new Date().getFullYear();
+
+  // Load user's progress
+  const { data: progress } = await supabase
+    .from("audit_checklist_progress")
+    .select("*")
+    .eq("user_id", user!.id)
+    .eq("tax_year", taxYear);
 
   const completedKeys = new Set(
     (progress || [])
@@ -30,7 +32,7 @@ export default async function ChecklistPage() {
       <ChecklistClient
         initialCompleted={Array.from(completedKeys)}
         userId={user!.id}
-        taxYear={settings?.tax_year ?? 2025}
+        taxYear={taxYear}
         companyName={settings?.company_name ?? "RBM Services Inc."}
       />
     </AppLayout>

--- a/src/app/filing/FilingClient.tsx
+++ b/src/app/filing/FilingClient.tsx
@@ -187,7 +187,7 @@ export default function FilingClient({
     return { total: items.length, done: doneCount, gateRemaining };
   });
 
-  // Suggested schedule: today = April 6, deadline = April 30
+  // Suggested schedule: based on today's date and the filing deadline
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const totalDays = getDaysRemaining(deadline);
@@ -208,7 +208,7 @@ export default function FilingClient({
   if (!tablesReady) {
     return (
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">2025 Filing Assistant</h1>
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">{taxYear} Filing Assistant</h1>
         <div className="card border-blue-200 bg-blue-50">
           <div className="flex gap-3">
             <svg className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -249,7 +249,7 @@ export default function FilingClient({
             disabled={loadingYear}
             className="border border-gray-300 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-navy-500 disabled:opacity-50"
           >
-            {[2023, 2024, 2025, 2026].map((y) => (
+            {Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - 2 + i).map((y) => (
               <option key={y} value={y}>{y}</option>
             ))}
           </select>

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,15 +1,24 @@
 import AppLayout from "@/components/AppLayout";
 import PrintButton from "./PrintButton";
+import { createClient } from "@/lib/supabase/server";
 
-export default function GuidePage() {
+export default async function GuidePage() {
+  const supabase = await createClient();
+  const { data: settings } = await supabase
+    .from("app_settings")
+    .select("tax_year, company_name")
+    .single();
+  const taxYear = settings?.tax_year ?? new Date().getFullYear();
+  const companyName = settings?.company_name ?? "RBM Services Inc.";
+
   return (
     <AppLayout>
-      <GuideContent />
+      <GuideContent taxYear={taxYear} companyName={companyName} />
     </AppLayout>
   );
 }
 
-function GuideContent() {
+function GuideContent({ taxYear, companyName }: { taxYear: number; companyName: string }) {
   return (
     <div className="max-w-4xl">
       {/* Header */}
@@ -17,7 +26,7 @@ function GuideContent() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">WinTeam 1095-C Setup Guide</h1>
           <p className="text-gray-500 text-sm mt-1">
-            RBM Services Inc. · Tax Year 2025
+            {companyName} · Tax Year {taxYear}
           </p>
         </div>
         <PrintButton />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -94,7 +94,7 @@ export default function LoginPage() {
         </div>
 
         <p className="text-center text-navy-300 text-xs mt-6">
-          Tax Year 2025 · ACA 1095-C Compliance
+          Tax Year {new Date().getFullYear()} · ACA 1095-C Compliance
         </p>
       </div>
     </div>

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -218,7 +218,7 @@ export default function SettingsClient({ settings, userId }: Props) {
                   )}
                   {method === "fpl" && (
                     <div className="text-xs text-gray-500 mt-0.5">
-                      Premium must be ≤ FPL threshold ($105.29/month for 2025)
+                      Premium must be ≤ FPL threshold (see FPL Monthly Threshold below)
                     </div>
                   )}
                 </div>
@@ -229,7 +229,7 @@ export default function SettingsClient({ settings, userId }: Props) {
 
         {/* Affordability thresholds */}
         <div className="card">
-          <h2 className="font-semibold text-gray-900 mb-4">Affordability Thresholds (2025)</h2>
+          <h2 className="font-semibold text-gray-900 mb-4">Affordability Thresholds ({form.tax_year})</h2>
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -245,7 +245,7 @@ export default function SettingsClient({ settings, userId }: Props) {
                 />
                 <span className="px-3 py-2 bg-gray-50 text-gray-500 text-sm border-l border-gray-300">decimal</span>
               </div>
-              <p className="text-xs text-gray-500 mt-1">2025: 0.0902 (9.02%)</p>
+              <p className="text-xs text-gray-500 mt-1">e.g. 0.0902 (9.02%) — update each year</p>
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -261,7 +261,7 @@ export default function SettingsClient({ settings, userId }: Props) {
                   className="flex-1 px-3 py-2 text-sm focus:outline-none"
                 />
               </div>
-              <p className="text-xs text-gray-500 mt-1">2025: $105.29/month</p>
+              <p className="text-xs text-gray-500 mt-1">e.g. $105.29/month — update each year</p>
             </div>
           </div>
         </div>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -10,6 +10,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   let isAdmin = false;
   let alertRows: EligibilityDashboardRow[] = [];
+  let navTaxYear = new Date().getFullYear();
+  let navExtensionFiled = false;
 
   if (user) {
     const { data: profile } = await supabase
@@ -18,6 +20,16 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       .eq("id", user.id)
       .single();
     isAdmin = profile?.role === "admin";
+
+    // Load settings for nav deadline display
+    const { data: navSettings } = await supabase
+      .from("app_settings")
+      .select("tax_year, extension_filed")
+      .single();
+    if (navSettings) {
+      navTaxYear = navSettings.tax_year ?? navTaxYear;
+      navExtensionFiled = navSettings.extension_filed ?? false;
+    }
 
     // Fetch eligibility alerts — gracefully skip if table doesn't exist yet
     try {
@@ -35,7 +47,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   return (
     <ToastProvider>
       <div className="min-h-screen flex flex-col">
-        <Navigation userEmail={user?.email} isAdmin={isAdmin} />
+        <Navigation userEmail={user?.email} isAdmin={isAdmin} taxYear={navTaxYear} extensionFiled={navExtensionFiled} />
         {alertRows.length > 0 && <EligibilityAlerts rows={alertRows} />}
         <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {children}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,8 +6,10 @@ import { createClient } from "@/lib/supabase/client";
 import { useState, useEffect } from "react";
 
 // Deadline badge helpers
-function getDeadlineDays(): number {
-  const deadline = new Date(2026, 3, 30); // April 30, 2026
+function getDeadlineDays(taxYear: number, extensionFiled: boolean): number {
+  const deadline = extensionFiled
+    ? new Date(taxYear + 1, 3, 30) // April 30 of following year
+    : new Date(taxYear + 1, 2, 31); // March 31 of following year
   const now = new Date();
   now.setHours(0, 0, 0, 0);
   return Math.ceil((deadline.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
@@ -19,15 +21,6 @@ function deadlineBadgeClass(days: number): string {
   return "bg-blue-600 text-white";
 }
 
-const FILING_NAV_ITEMS = [
-  { href: "/filing", label: "2025 Filing", showDeadline: true },
-  { href: "/filing/access", label: "Access Plan" },
-  { href: "/checklist", label: "Audit Checklist" },
-  { href: "/wizard", label: "Code Wizard" },
-  { href: "/tracker", label: "Employee Tracker" },
-  { href: "/guide", label: "WinTeam Guide" },
-];
-
 const YEAR_ROUND_NAV_ITEMS = [
   { href: "/payroll", label: "Pay Period" },
   { href: "/payroll/offers", label: "Offer Letters" },
@@ -36,19 +29,30 @@ const YEAR_ROUND_NAV_ITEMS = [
 interface NavigationProps {
   userEmail?: string | null;
   isAdmin?: boolean;
+  taxYear?: number;
+  extensionFiled?: boolean;
 }
 
-export default function Navigation({ userEmail, isAdmin }: NavigationProps) {
+export default function Navigation({ userEmail, isAdmin, taxYear = new Date().getFullYear(), extensionFiled = false }: NavigationProps) {
   const pathname = usePathname();
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [deadlineDays, setDeadlineDays] = useState<number | null>(null);
 
+  const filingNavItems = [
+    { href: "/filing", label: `${taxYear} Filing`, showDeadline: true },
+    { href: "/filing/access", label: "Access Plan" },
+    { href: "/checklist", label: "Audit Checklist" },
+    { href: "/wizard", label: "Code Wizard" },
+    { href: "/tracker", label: "Employee Tracker" },
+    { href: "/guide", label: "WinTeam Guide" },
+  ];
+
   useEffect(() => {
-    const days = getDeadlineDays();
+    const days = getDeadlineDays(taxYear, extensionFiled);
     // Only show badge if deadline hasn't passed
     if (days >= 0) setDeadlineDays(days);
-  }, []);
+  }, [taxYear, extensionFiled]);
 
   async function handleSignOut() {
     const supabase = createClient();
@@ -100,7 +104,7 @@ export default function Navigation({ userEmail, isAdmin }: NavigationProps) {
 
           {/* Desktop nav */}
           <div className="hidden md:flex items-center gap-1">
-            {FILING_NAV_ITEMS.map((item) => (
+            {filingNavItems.map((item) => (
               <Link key={item.href} href={item.href} className={`${linkClass(item.href)} flex items-center gap-1.5`}>
                 {item.label}
                 {'showDeadline' in item && item.showDeadline && deadlineDays !== null && (
@@ -161,7 +165,7 @@ export default function Navigation({ userEmail, isAdmin }: NavigationProps) {
             <div className="px-3 py-1 text-navy-400 text-xs font-semibold uppercase tracking-wider">
               Filing Tools
             </div>
-            {FILING_NAV_ITEMS.map((item) => (
+            {filingNavItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}

--- a/src/lib/walkthroughs-data.ts
+++ b/src/lib/walkthroughs-data.ts
@@ -1002,7 +1002,7 @@ export const WALKTHROUGHS: Record<string, Walkthrough> = {
       { step: 3, instruction: 'Change the Output Type to 1095-C Electronic File (NOT Preview).', warning: 'You are now generating the real filing file. Make sure all spot-checks from previous steps were completed with a clean preview before proceeding.' },
       { step: 4, instruction: 'Set the employee range to All.' },
       { step: 5, instruction: 'Click Generate or Run.' },
-      { step: 6, instruction: 'When WinTeam prompts you to save the file, save it to a secure folder. Name it clearly, for example: "1095C_2025_[CompanyName]_[Date].xml".' },
+      { step: 6, instruction: 'When WinTeam prompts you to save the file, save it to a secure folder. Name it clearly, for example: "1095C_[TaxYear]_[CompanyName]_[Date].xml".' },
       { step: 7, instruction: 'Verify the file was saved successfully and note the file location.' },
       { step: 8, instruction: 'Mark this item complete.' },
     ],

--- a/supabase/filing_assistant.sql
+++ b/supabase/filing_assistant.sql
@@ -12,7 +12,7 @@ alter table app_settings
 -- ============================================================
 create table if not exists filing_phases (
   id uuid default uuid_generate_v4() primary key,
-  tax_year integer not null default 2025,
+  tax_year integer not null default extract(year from current_date)::integer,
   phase_number integer not null check (phase_number in (1, 2, 3, 4)),
   phase_name text not null,
   status text default 'locked'
@@ -30,12 +30,21 @@ alter table filing_phases enable row level security;
 create policy "Authenticated users can manage filing phases"
   on filing_phases for all using (auth.role() = 'authenticated');
 
--- Seed phases for 2025 (upsert so safe to run multiple times)
-insert into filing_phases (tax_year, phase_number, phase_name, status) values
-  (2025, 1, 'Audit 2024 WinTeam Setup', 'in_progress'),
-  (2025, 2, 'Fix Issues and Roll Forward to 2025', 'locked'),
-  (2025, 3, '2025 Data Catch-Up', 'locked'),
-  (2025, 4, 'Generate, Verify, and File', 'locked')
+-- Seed initial phases for the current year (upsert so safe to run multiple times).
+-- The app auto-seeds phases for any selected year via FilingClient.seedPhases(),
+-- so this SQL seed is only needed for the very first run.
+insert into filing_phases (tax_year, phase_number, phase_name, status)
+select
+  extract(year from current_date)::integer,
+  phase_number,
+  case phase_number
+    when 1 then 'Audit ' || (extract(year from current_date)::integer - 1)::text || ' WinTeam Setup'
+    when 2 then 'Fix Issues and Roll Forward to ' || extract(year from current_date)::text
+    when 3 then extract(year from current_date)::text || ' Data Catch-Up'
+    when 4 then 'Generate, Verify, and File'
+  end,
+  case phase_number when 1 then 'in_progress' else 'locked' end
+from (values (1), (2), (3), (4)) as t(phase_number)
 on conflict (tax_year, phase_number) do nothing;
 
 -- ============================================================
@@ -43,7 +52,7 @@ on conflict (tax_year, phase_number) do nothing;
 -- ============================================================
 create table if not exists filing_checklist_progress (
   id uuid default uuid_generate_v4() primary key,
-  tax_year integer not null default 2025,
+  tax_year integer not null default extract(year from current_date)::integer,
   item_key text not null,
   is_complete boolean default false,
   completed_by uuid references profiles(id),
@@ -63,7 +72,7 @@ create policy "Authenticated users can manage filing progress"
 -- ============================================================
 create table if not exists filing_issues (
   id uuid default uuid_generate_v4() primary key,
-  tax_year integer not null default 2025,
+  tax_year integer not null default extract(year from current_date)::integer,
   phase_found integer not null,
   category text not null check (category in (
     'benefit_setup','eligibility_setup','company_setup',
@@ -97,7 +106,7 @@ create policy "Authenticated users can manage filing issues"
 create table if not exists employee_filing_status (
   id uuid default uuid_generate_v4() primary key,
   employee_id uuid references employees(id) on delete cascade,
-  tax_year integer not null default 2025,
+  tax_year integer not null default extract(year from current_date)::integer,
   benefit_package_assigned boolean default false,
   stability_start_date_set boolean default false,
   plan_enrolled text check (plan_enrolled in ('P1','P2','P3','declined',null)),

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -30,7 +30,7 @@ create policy "Users can update their own profile"
 -- ============================================================
 create table app_settings (
   id uuid default uuid_generate_v4() primary key,
-  tax_year integer default 2025,
+  tax_year integer default extract(year from current_date)::integer,
   company_name text default 'RBM Services Inc.',
   company_ein text default '87-1234567',
   contact_phone text default '(801) 555-0100',
@@ -54,8 +54,8 @@ create policy "Only admins can update settings"
     exists (select 1 from profiles where id = auth.uid() and role = 'admin')
   );
 
--- Insert default settings row
-insert into app_settings default values;
+-- Insert default settings row (tax_year defaults to current calendar year)
+insert into app_settings (tax_year) values (extract(year from current_date)::integer);
 
 -- ============================================================
 -- Table: employees
@@ -136,7 +136,7 @@ create policy "Authenticated users can manage dependents"
 create table audit_checklist_progress (
   id uuid default uuid_generate_v4() primary key,
   user_id uuid references profiles(id) on delete cascade,
-  tax_year integer default 2025,
+  tax_year integer default extract(year from current_date)::integer,
   checklist_item_key text not null,
   is_complete boolean default false,
   completed_at timestamptz,
@@ -156,7 +156,7 @@ create policy "Users can manage their own checklist progress"
 create table wizard_sessions (
   id uuid default uuid_generate_v4() primary key,
   user_id uuid references profiles(id) on delete cascade,
-  tax_year integer default 2025,
+  tax_year integer default extract(year from current_date)::integer,
   employee_id uuid references employees(id) on delete set null,
   answers jsonb not null,
   result_line14 text,


### PR DESCRIPTION
Audit and fix every hardcoded year/date across the app so it works correctly for any tax year selected by the user.

Changes:
- Navigation deadline badge now derives from settings tax_year + extension_filed
- AppLayout fetches settings and passes taxYear/extensionFiled to Navigation
- Checklist page query uses settings.tax_year instead of hardcoded 2025
- FilingClient heading and year dropdown are fully dynamic
- Guide page loads settings and renders tax year dynamically
- Login page uses current calendar year
- Settings page threshold section header uses form tax_year
- SQL column defaults use extract(year from current_date) instead of 2025
- Filing assistant SQL seed generates phase names from current year

Closes #19

Generated with [Claude Code](https://claude.ai/code)