### PR TITLE
feat: add screenshot upload to filing assistant checklist items

### DIFF
--- a/src/app/actions/screenshots.ts
+++ b/src/app/actions/screenshots.ts
@@ -1,0 +1,195 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import type { ChecklistScreenshot } from "@/lib/types";
+
+// Upload a screenshot file to Supabase Storage and record metadata
+export async function uploadScreenshot(formData: FormData): Promise<{
+  success: boolean;
+  screenshot?: ChecklistScreenshot;
+  error?: string;
+}> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const file = formData.get("file") as File;
+  const itemKey = formData.get("item_key") as string;
+  const taxYear = parseInt(formData.get("tax_year") as string);
+  const caption = formData.get("caption") as string | null;
+
+  if (!file || !itemKey || !taxYear) {
+    return { success: false, error: "Missing required fields" };
+  }
+
+  // Validate file type
+  const allowedTypes = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+  if (!allowedTypes.includes(file.type)) {
+    return {
+      success: false,
+      error: "Only JPEG, PNG, WebP, and GIF files are allowed",
+    };
+  }
+
+  // Validate file size (5MB)
+  if (file.size > 5 * 1024 * 1024) {
+    return { success: false, error: "File must be under 5MB" };
+  }
+
+  // Generate storage path: {taxYear}/{itemKey}/{uuid}.{ext}
+  const ext = file.name.split(".").pop();
+  const fileName = `${crypto.randomUUID()}.${ext}`;
+  const storagePath = `${taxYear}/${itemKey}/${fileName}`;
+
+  // Upload to Supabase Storage
+  const { error: uploadError } = await supabase.storage
+    .from("walkthrough-screenshots")
+    .upload(storagePath, file, {
+      contentType: file.type,
+      upsert: false,
+    });
+
+  if (uploadError) {
+    return { success: false, error: uploadError.message };
+  }
+
+  // Get current max display_order for this item
+  const { data: existing } = await supabase
+    .from("checklist_screenshots")
+    .select("display_order")
+    .eq("item_key", itemKey)
+    .eq("tax_year", taxYear)
+    .order("display_order", { ascending: false })
+    .limit(1);
+
+  const nextOrder =
+    existing && existing.length > 0 ? existing[0].display_order + 1 : 0;
+
+  // Insert metadata record
+  const { data: screenshot, error: dbError } = await supabase
+    .from("checklist_screenshots")
+    .insert({
+      tax_year: taxYear,
+      item_key: itemKey,
+      storage_path: storagePath,
+      file_name: file.name,
+      file_size: file.size,
+      mime_type: file.type,
+      caption: caption || null,
+      uploaded_by: user.id,
+      display_order: nextOrder,
+    })
+    .select()
+    .single();
+
+  if (dbError) {
+    // Clean up the uploaded file if DB insert fails
+    await supabase.storage
+      .from("walkthrough-screenshots")
+      .remove([storagePath]);
+    return { success: false, error: dbError.message };
+  }
+
+  // Return with camelCase shape matching ChecklistScreenshot
+  const result: ChecklistScreenshot = {
+    id: screenshot.id,
+    taxYear: screenshot.tax_year,
+    itemKey: screenshot.item_key,
+    storagePath: screenshot.storage_path,
+    fileName: screenshot.file_name,
+    fileSize: screenshot.file_size,
+    mimeType: screenshot.mime_type,
+    caption: screenshot.caption,
+    uploadedBy: screenshot.uploaded_by,
+    uploadedAt: screenshot.uploaded_at,
+    displayOrder: screenshot.display_order,
+  };
+
+  return { success: true, screenshot: result };
+}
+
+// Get all screenshots for a checklist item with signed URLs
+export async function getScreenshots(
+  itemKey: string,
+  taxYear: number
+): Promise<ChecklistScreenshot[]> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data: screenshots } = await supabase
+    .from("checklist_screenshots")
+    .select("*")
+    .eq("item_key", itemKey)
+    .eq("tax_year", taxYear)
+    .order("display_order", { ascending: true });
+
+  if (!screenshots || screenshots.length === 0) return [];
+
+  // Generate signed URLs for each screenshot (valid for 1 hour)
+  const withUrls = await Promise.all(
+    screenshots.map(async (s) => {
+      const { data: urlData } = await supabase.storage
+        .from("walkthrough-screenshots")
+        .createSignedUrl(s.storage_path, 3600);
+      const result: ChecklistScreenshot = {
+        id: s.id,
+        taxYear: s.tax_year,
+        itemKey: s.item_key,
+        storagePath: s.storage_path,
+        fileName: s.file_name,
+        fileSize: s.file_size,
+        mimeType: s.mime_type,
+        caption: s.caption,
+        uploadedBy: s.uploaded_by,
+        uploadedAt: s.uploaded_at,
+        displayOrder: s.display_order,
+        signedUrl: urlData?.signedUrl,
+      };
+      return result;
+    })
+  );
+
+  return withUrls;
+}
+
+// Delete a screenshot (admin only — enforced at RLS level)
+export async function deleteScreenshot(
+  screenshotId: string
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  // Fetch storage path before deleting metadata
+  const { data: screenshot } = await supabase
+    .from("checklist_screenshots")
+    .select("storage_path")
+    .eq("id", screenshotId)
+    .single();
+
+  if (!screenshot) return { success: false, error: "Screenshot not found" };
+
+  // Delete the file from storage
+  const { error: storageError } = await supabase.storage
+    .from("walkthrough-screenshots")
+    .remove([screenshot.storage_path]);
+
+  if (storageError) return { success: false, error: storageError.message };
+
+  // Delete metadata record
+  const { error: dbError } = await supabase
+    .from("checklist_screenshots")
+    .delete()
+    .eq("id", screenshotId);
+
+  if (dbError) return { success: false, error: dbError.message };
+
+  return { success: true };
+}

--- a/src/app/filing/phase/[number]/PhaseClient.tsx
+++ b/src/app/filing/phase/[number]/PhaseClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { useToast } from "@/components/Toast";
 import WalkthroughOverlay from "@/components/WalkthroughOverlay";
+import ScreenshotPanel from "@/components/ScreenshotPanel";
 import {
   getFilingChecklist,
   getGateItems,
@@ -33,6 +34,7 @@ interface ProgressRow {
 
 interface Props {
   userId: string;
+  userRole: "admin" | "hr_user";
   phaseNumber: 1 | 2 | 3 | 4;
   taxYear: number;
   initialPhase: FilingPhaseRow | null;
@@ -86,6 +88,7 @@ const CATEGORIES = [
 
 export default function PhaseClient({
   userId,
+  userRole,
   phaseNumber,
   taxYear,
   initialPhase,
@@ -128,6 +131,7 @@ export default function PhaseClient({
   });
 
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [screenshotItems, setScreenshotItems] = useState<Set<string>>(new Set());
   const [walkthroughItem, setWalkthroughItem] = useState<FilingChecklistItem | null>(null);
   const [issueDrawerOpen, setIssueDrawerOpen] = useState(false);
   const [issueForm, setIssueForm] = useState<IssueForm>(DEFAULT_ISSUE);
@@ -522,6 +526,31 @@ export default function PhaseClient({
                           </div>
                           {assignments[item.key] && (
                             <p className="text-xs text-gray-400 mt-0.5">Assigned to: {assignments[item.key]}</p>
+                          )}
+
+                          {/* Screenshot toggle */}
+                          <button
+                            onClick={() => setScreenshotItems((prev) => {
+                              const next = new Set(prev);
+                              if (next.has(item.key)) next.delete(item.key);
+                              else next.add(item.key);
+                              return next;
+                            })}
+                            className="mt-2 text-xs text-navy-600 hover:text-navy-800 flex items-center gap-1"
+                          >
+                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            {screenshotItems.has(item.key) ? "Hide screenshots ▲" : "Screenshots ▼"}
+                          </button>
+
+                          {/* Screenshot panel — lazy mounts on first open */}
+                          {screenshotItems.has(item.key) && (
+                            <ScreenshotPanel
+                              itemKey={item.key}
+                              taxYear={taxYear}
+                              isAdmin={userRole === "admin"}
+                            />
                           )}
                         </div>
                       </div>

--- a/src/app/filing/phase/[number]/page.tsx
+++ b/src/app/filing/phase/[number]/page.tsx
@@ -20,6 +20,13 @@ export default async function PhasePage({ params, searchParams }: Props) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
+  // Load user role
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user!.id)
+    .single();
+
   // Load phase info
   const { data: phase } = await supabase
     .from("filing_phases")
@@ -38,6 +45,7 @@ export default async function PhasePage({ params, searchParams }: Props) {
     <AppLayout>
       <PhaseClient
         userId={user!.id}
+        userRole={profile?.role ?? "hr_user"}
         phaseNumber={phaseNum as 1 | 2 | 3 | 4}
         taxYear={taxYear}
         initialPhase={phase ?? null}

--- a/src/components/ScreenshotPanel.tsx
+++ b/src/components/ScreenshotPanel.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  uploadScreenshot,
+  getScreenshots,
+  deleteScreenshot,
+} from "@/app/actions/screenshots";
+import type { ChecklistScreenshot } from "@/lib/types";
+
+interface Props {
+  itemKey: string;
+  taxYear: number;
+  isAdmin: boolean;
+}
+
+export default function ScreenshotPanel({ itemKey, taxYear, isAdmin }: Props) {
+  const [screenshots, setScreenshots] = useState<ChecklistScreenshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [caption, setCaption] = useState("");
+  const [lightbox, setLightbox] = useState<ChecklistScreenshot | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    getScreenshots(itemKey, taxYear).then((data) => {
+      setScreenshots(data);
+      setLoading(false);
+    });
+  }, [itemKey, taxYear]);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploadError(null);
+    setUploading(true);
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("item_key", itemKey);
+    formData.append("tax_year", String(taxYear));
+    if (caption.trim()) formData.append("caption", caption.trim());
+
+    const result = await uploadScreenshot(formData);
+
+    if (result.success && result.screenshot) {
+      setScreenshots((prev) => [...prev, result.screenshot!]);
+      setCaption("");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    } else {
+      setUploadError(result.error ?? "Upload failed");
+    }
+
+    setUploading(false);
+  }
+
+  async function handleDelete(id: string) {
+    const result = await deleteScreenshot(id);
+    if (result.success) {
+      setScreenshots((prev) => prev.filter((s) => s.id !== id));
+      if (lightbox?.id === id) setLightbox(null);
+    }
+  }
+
+  return (
+    <div className="mt-3 border border-dashed border-blue-200 rounded-lg p-3 bg-blue-50/30">
+      <p className="text-xs font-medium text-gray-600 mb-2 flex items-center gap-1.5">
+        <svg
+          className="w-3.5 h-3.5 text-gray-400 flex-shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+        Reference Screenshots
+      </p>
+
+      {loading ? (
+        <p className="text-xs text-gray-400">Loading...</p>
+      ) : (
+        <>
+          {screenshots.length > 0 ? (
+            <div className="flex flex-wrap gap-2 mb-3">
+              {screenshots.map((s) => (
+                <div key={s.id} className="relative group">
+                  <button
+                    onClick={() => setLightbox(s)}
+                    className="block w-20 h-20 rounded border border-gray-200 overflow-hidden bg-white hover:border-navy-400 transition-colors"
+                    title={s.caption ?? s.fileName}
+                  >
+                    {s.signedUrl ? (
+                      <img
+                        src={s.signedUrl}
+                        alt={s.caption ?? s.fileName}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-gray-300">
+                        <svg
+                          className="w-6 h-6"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                          />
+                        </svg>
+                      </div>
+                    )}
+                  </button>
+                  {isAdmin && (
+                    <button
+                      onClick={() => handleDelete(s.id)}
+                      className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-red-500 text-white rounded-full text-xs hidden group-hover:flex items-center justify-center leading-none"
+                      title="Delete screenshot"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-gray-400 mb-3">
+              No screenshots yet. Add one to create a permanent visual guide for
+              this step.
+            </p>
+          )}
+
+          {/* Upload controls */}
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="Optional caption..."
+              value={caption}
+              onChange={(e) => setCaption(e.target.value)}
+              className="flex-1 text-xs border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-navy-500 bg-white"
+            />
+            <label
+              className={`text-xs btn-secondary py-1.5 px-2 cursor-pointer whitespace-nowrap ${
+                uploading ? "opacity-50 pointer-events-none" : ""
+              }`}
+            >
+              {uploading ? "Uploading..." : "+ Add Screenshot"}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif"
+                className="hidden"
+                onChange={handleFileChange}
+                disabled={uploading}
+              />
+            </label>
+          </div>
+
+          {uploadError && (
+            <p className="text-xs text-red-600 mt-1.5">{uploadError}</p>
+          )}
+        </>
+      )}
+
+      {/* Lightbox */}
+      {lightbox && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70"
+          onClick={() => setLightbox(null)}
+        >
+          <div
+            className="relative max-w-4xl max-h-[90vh] bg-white rounded-xl overflow-hidden shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setLightbox(null)}
+              className="absolute top-2 right-2 z-10 w-7 h-7 bg-black/50 text-white rounded-full flex items-center justify-center hover:bg-black/70 transition-colors"
+              aria-label="Close"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+            {lightbox.signedUrl && (
+              <img
+                src={lightbox.signedUrl}
+                alt={lightbox.caption ?? lightbox.fileName}
+                className="max-w-full max-h-[85vh] object-contain"
+              />
+            )}
+            {lightbox.caption && (
+              <p className="px-4 py-2 text-sm text-gray-600 border-t border-gray-100">
+                {lightbox.caption}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -348,6 +348,22 @@ export interface FilingIssue {
   createdAt: string;
 }
 
+export interface ChecklistScreenshot {
+  id: string;
+  taxYear: number;
+  itemKey: string;
+  storagePath: string;
+  fileName: string;
+  fileSize: number | null;
+  mimeType: string | null;
+  caption: string | null;
+  uploadedBy: string | null;
+  uploadedAt: string;
+  displayOrder: number;
+  // Client-side only — signed URL fetched separately
+  signedUrl?: string;
+}
+
 export interface EmployeeFilingStatus {
   id: string;
   employeeId: string;

--- a/supabase/filing_assistant.sql
+++ b/supabase/filing_assistant.sql
@@ -134,3 +134,103 @@ alter table employee_filing_status enable row level security;
 
 create policy "Authenticated users can manage employee filing status"
   on employee_filing_status for all using (auth.role() = 'authenticated');
+
+-- ============================================================
+-- Storage: walkthrough-screenshots bucket
+-- ============================================================
+
+-- Create storage bucket for walkthrough screenshots
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'walkthrough-screenshots',
+  'walkthrough-screenshots',
+  false,
+  5242880,  -- 5MB limit per file
+  array['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+)
+on conflict (id) do nothing;
+
+-- RLS policies for the bucket
+do $$ begin
+  create policy "Authenticated users can upload screenshots"
+    on storage.objects for insert
+    with check (
+      bucket_id = 'walkthrough-screenshots' and
+      auth.role() = 'authenticated'
+    );
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "Authenticated users can view screenshots"
+    on storage.objects for select
+    using (
+      bucket_id = 'walkthrough-screenshots' and
+      auth.role() = 'authenticated'
+    );
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "Admins can delete screenshots"
+    on storage.objects for delete
+    using (
+      bucket_id = 'walkthrough-screenshots' and
+      exists (
+        select 1 from profiles
+        where id = auth.uid() and role = 'admin'
+      )
+    );
+exception when duplicate_object then null;
+end $$;
+
+-- ============================================================
+-- Table: checklist_screenshots
+-- ============================================================
+
+create table if not exists checklist_screenshots (
+  id uuid default uuid_generate_v4() primary key,
+  tax_year integer not null,
+  item_key text not null,
+  storage_path text not null,
+  -- path in the walkthrough-screenshots bucket
+  -- format: {tax_year}/{item_key}/{uuid}.{ext}
+  file_name text not null,
+  file_size integer,
+  mime_type text,
+  caption text,
+  -- optional caption the uploader adds e.g. "This is what it
+  -- looks like when correctly configured"
+  uploaded_by uuid references profiles(id),
+  uploaded_at timestamptz default now(),
+  display_order integer default 0
+  -- allows multiple screenshots per item, ordered
+);
+
+alter table checklist_screenshots enable row level security;
+
+do $$ begin
+  create policy "Authenticated users can view screenshots metadata"
+    on checklist_screenshots for select
+    using (auth.role() = 'authenticated');
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "Authenticated users can insert screenshot metadata"
+    on checklist_screenshots for insert
+    with check (auth.role() = 'authenticated');
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "Admins can delete screenshot metadata"
+    on checklist_screenshots for delete
+    using (
+      exists (
+        select 1 from profiles
+        where id = auth.uid() and role = 'admin'
+      )
+    );
+exception when duplicate_object then null;
+end $$;


### PR DESCRIPTION
Adds permanent visual guides to each checklist item on the phase pages.

## Changes
- Supabase storage bucket and RLS policies for walkthrough screenshots
- `checklist_screenshots` metadata table
- `ChecklistScreenshot` type in `src/lib/types.ts`
- Server actions: uploadScreenshot, getScreenshots, deleteScreenshot
- ScreenshotPanel component with thumbnail grid, lightbox, and admin delete
- Integrated into each checklist item on filing phase pages

Closes #25

Generated with [Claude Code](https://claude.ai/code)