### PR TITLE
fix: make admin panel visible — add preferred_language migration

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -18,14 +18,27 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   let preferredLanguage: Language = 'en';
 
   if (user) {
-    const { data: profile } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from("profiles")
       .select("role, full_name, preferred_language")
       .eq("id", user.id)
       .single();
-    isAdmin = profile?.role === "admin";
-    userFullName = profile?.full_name ?? null;
-    if (profile?.preferred_language === 'es') preferredLanguage = 'es';
+
+    // If preferred_language column doesn't exist yet (migration not run),
+    // fall back to selecting only the critical fields so isAdmin still works.
+    if (profileError && !profile) {
+      const { data: basicProfile } = await supabase
+        .from("profiles")
+        .select("role, full_name")
+        .eq("id", user.id)
+        .single();
+      isAdmin = basicProfile?.role === "admin";
+      userFullName = basicProfile?.full_name ?? null;
+    } else {
+      isAdmin = profile?.role === "admin";
+      userFullName = profile?.full_name ?? null;
+      if (profile?.preferred_language === 'es') preferredLanguage = 'es';
+    }
 
     // Load settings for nav deadline display
     const { data: navSettings } = await supabase

--- a/supabase/admin_migration.sql
+++ b/supabase/admin_migration.sql
@@ -1,0 +1,38 @@
+-- Admin feature migration
+-- Run this in the Supabase SQL Editor (Dashboard → SQL Editor → New query)
+-- Safe to run multiple times — all statements are idempotent.
+
+-- ============================================================
+-- 1. Add preferred_language column to profiles
+-- ============================================================
+alter table profiles
+  add column if not exists preferred_language text
+  default 'en'
+  check (preferred_language in ('en', 'es'));
+
+-- ============================================================
+-- 2. Admin RLS policies — allow admins to see/update all rows
+-- ============================================================
+do $$ begin
+  create policy "Admins can view all profiles"
+    on profiles for select
+    using (
+      exists (
+        select 1 from profiles p
+        where p.id = auth.uid() and p.role = 'admin'
+      )
+    );
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "Admins can update all profiles"
+    on profiles for update
+    using (
+      exists (
+        select 1 from profiles p
+        where p.id = auth.uid() and p.role = 'admin'
+      )
+    );
+exception when duplicate_object then null;
+end $$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -13,6 +13,7 @@ create table profiles (
   full_name text,
   email text,
   role text default 'hr_user' check (role in ('admin', 'hr_user')),
+  preferred_language text default 'en' check (preferred_language in ('en', 'es')),
   created_at timestamptz default now()
 );
 
@@ -23,6 +24,24 @@ create policy "Users can view their own profile"
 
 create policy "Users can update their own profile"
   on profiles for update using (auth.uid() = id);
+
+create policy "Admins can view all profiles"
+  on profiles for select
+  using (
+    exists (
+      select 1 from profiles p
+      where p.id = auth.uid() and p.role = 'admin'
+    )
+  );
+
+create policy "Admins can update all profiles"
+  on profiles for update
+  using (
+    exists (
+      select 1 from profiles p
+      where p.id = auth.uid() and p.role = 'admin'
+    )
+  );
 
 -- ============================================================
 -- Table: app_settings


### PR DESCRIPTION
Fixes #31

All admin code was already built. The admin button was invisible because AppLayout selected `preferred_language` from profiles before the column existed, causing the profile query to fail and isAdmin to always be false.

Changes:
- AppLayout: fallback query if preferred_language column missing
- supabase/schema.sql: add preferred_language + admin RLS policies
- supabase/admin_migration.sql: idempotent migration for existing DB

Generated with [Claude Code](https://claude.ai/code)