### PR TITLE
fix: password reset email not being sent

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -100,10 +100,9 @@ export async function resetUserPassword(
 ): Promise<{ success: boolean; error?: string }> {
   try {
     await requireAdmin();
-    const adminClient = createAdminClient();
-    const { error } = await adminClient.auth.admin.generateLink({
-      type: "recovery",
-      email,
+    const supabase = await createClient();
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: "https://rbmhr.com/auth/callback",
     });
 
     if (error) return { success: false, error: error.message };


### PR DESCRIPTION
Fixes #36

The `resetUserPassword` server action was using `generateLink` which only creates a recovery URL server-side without emailing it. Replace with `resetPasswordForEmail` so Supabase actually delivers the email to the user.

Generated with [Claude Code](https://claude.ai/code)