### PR TITLE
fix: rebuild password reset flow with client-side session detection

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -12,13 +12,14 @@ export async function GET(request: NextRequest) {
 
   // Handle PKCE code exchange (standard OAuth flow)
   if (code) {
-    await supabase.auth.exchangeCodeForSession(code);
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
 
-    // If this was an invite or recovery, go to set-password
-    if (type === "invite" || type === "recovery") {
-      return NextResponse.redirect(new URL("/set-password", request.url));
+    if (!error) {
+      if (type === "invite" || type === "recovery") {
+        return NextResponse.redirect(new URL("/set-password", request.url));
+      }
+      return NextResponse.redirect(new URL(next, request.url));
     }
-    return NextResponse.redirect(new URL(next, request.url));
   }
 
   // Handle email OTP tokens (invite, recovery, email change)
@@ -38,6 +39,6 @@ export async function GET(request: NextRequest) {
 
   // Something went wrong — redirect to login with error
   return NextResponse.redirect(
-    new URL("/login?error=auth_callback_failed", request.url)
+    new URL("/login?error=link_expired", request.url)
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -46,7 +46,7 @@ function LoginContent() {
 
     const supabase = createClient();
     await supabase.auth.resetPasswordForEmail(forgotEmail, {
-      redirectTo: "https://rbmhr.com/auth/callback",
+      redirectTo: "https://rbmhr.com/auth/callback?type=recovery",
     });
 
     // Always show success — do not reveal whether email exists
@@ -85,9 +85,9 @@ function LoginContent() {
             <>
               <h2 className="text-lg font-semibold text-gray-900 mb-6">{t("welcomeSubtitle")}</h2>
 
-              {callbackError === "auth_callback_failed" && (
+              {(callbackError === "auth_callback_failed" || callbackError === "link_expired") && (
                 <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">
-                  Your sign-in link has expired. Please try again.
+                  Your link has expired. Please request a new one.
                 </div>
               )}
 

--- a/src/app/set-password/SetPasswordClient.tsx
+++ b/src/app/set-password/SetPasswordClient.tsx
@@ -1,18 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 
 export default function SetPasswordClient() {
+  const [isValidSession, setIsValidSession] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const router = useRouter();
+  const supabase = createClient();
 
-  async function handleSubmit(e: React.FormEvent) {
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (event) => {
+      if (event === "PASSWORD_RECOVERY" || event === "SIGNED_IN") {
+        setIsValidSession(true);
+      }
+      setIsLoading(false);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  async function handleSetPassword(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
 
@@ -26,21 +44,42 @@ export default function SetPasswordClient() {
       return;
     }
 
-    setLoading(true);
-    const supabase = createClient();
+    setSubmitting(true);
     const { error } = await supabase.auth.updateUser({ password });
 
     if (error) {
       setError(error.message);
-      setLoading(false);
+      setSubmitting(false);
     } else {
       setSuccess(true);
-      setTimeout(() => router.push("/"), 2000);
+      setTimeout(() => router.push("/"), 1500);
     }
   }
 
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="text-sm text-gray-500">Verifying your link…</div>
+      </div>
+    );
+  }
+
+  if (!isValidSession) {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-gray-700 text-sm">
+          This link has expired or has already been used. Please request a new
+          password reset from the login page.
+        </p>
+        <a href="/login" className="text-sm text-navy-600 hover:underline font-medium">
+          Back to login
+        </a>
+      </div>
+    );
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSetPassword} className="space-y-4">
       {error && (
         <div className="p-3 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">
           {error}
@@ -49,7 +88,7 @@ export default function SetPasswordClient() {
 
       {success ? (
         <div className="p-3 bg-green-50 border border-green-200 text-green-700 rounded-md text-sm text-center">
-          Password set successfully! Redirecting…
+          Password set! Taking you to the app…
         </div>
       ) : (
         <>
@@ -57,37 +96,55 @@ export default function SetPasswordClient() {
             <label className="block text-sm font-medium text-gray-700 mb-1">
               New password
             </label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              minLength={8}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-navy-500 focus:border-transparent"
-              placeholder="Min. 8 characters"
-            />
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-navy-500 focus:border-transparent pr-10"
+                placeholder="Min. 8 characters"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-gray-600 text-xs"
+              >
+                {showPassword ? "Hide" : "Show"}
+              </button>
+            </div>
           </div>
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Confirm password
             </label>
-            <input
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-navy-500 focus:border-transparent"
-              placeholder="Re-enter your password"
-            />
+            <div className="relative">
+              <input
+                type={showConfirm ? "text" : "password"}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-navy-500 focus:border-transparent pr-10"
+                placeholder="Re-enter your password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirm((v) => !v)}
+                className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-gray-600 text-xs"
+              >
+                {showConfirm ? "Hide" : "Show"}
+              </button>
+            </div>
           </div>
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={submitting}
             className="w-full btn-primary py-2.5 text-sm"
           >
-            {loading ? "Setting password…" : "Set password"}
+            {submitting ? "Setting password…" : "Set Password"}
           </button>
         </>
       )}

--- a/src/app/set-password/page.tsx
+++ b/src/app/set-password/page.tsx
@@ -1,40 +1,6 @@
-import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
 import SetPasswordClient from "./SetPasswordClient";
 
-export default async function SetPasswordPage() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return (
-      <div className="min-h-screen bg-navy-700 flex items-center justify-center px-4">
-        <div className="w-full max-w-md">
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-white rounded-2xl shadow-lg mb-4">
-              <span className="text-navy-700 font-bold text-xl">1095</span>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl shadow-xl p-8 text-center">
-            <p className="text-gray-700 mb-4">
-              This link has expired. Contact your administrator to send a new
-              invitation.
-            </p>
-            <a
-              href="/login"
-              className="text-sm text-navy-600 hover:underline font-medium"
-            >
-              Back to sign in
-            </a>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
+export default function SetPasswordPage() {
   return (
     <div className="min-h-screen bg-navy-700 flex items-center justify-center px-4">
       <div className="w-full max-w-md">


### PR DESCRIPTION
Fixes #36

Rebuilds the entire password reset flow to fix email delivery and session detection issues.

- `redirectTo` now includes `?type=recovery`
- `SetPasswordClient` uses `onAuthStateChange` to detect `PASSWORD_RECOVERY` event instead of server-side `getSession()`
- Loading/expired states on set-password page
- Show/hide password toggles
- Auth callback redirects to `link_expired` error param on failure

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/joerickson/1095c-hr-toolkit/tree/claude/pr-37-20260406-2236