### PR TITLE
fix: auth callback cookie handling and PKCE flow

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,6 +43,12 @@ export async function middleware(request: NextRequest) {
     return supabaseResponse;
   }
 
+  // Allow unauthenticated access to set-password — users arrive here after
+  // the auth callback redirect and may not yet be recognized as authenticated
+  if (pathname.startsWith("/set-password")) {
+    return supabaseResponse;
+  }
+
   // All other routes require auth
   if (!user) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
Add /set-password to public routes in middleware so unauthenticated users can reach the page after the auth callback redirect.

Users who clicked invite or password reset links were being redirected to /login instead of /set-password because the middleware required auth for all routes not explicitly listed as public.

Closes #39

Generated with [Claude Code](https://claude.ai/code)