### PR TITLE
fix: repair invite link and password reset email auth flows

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -46,7 +46,7 @@ function LoginContent() {
 
     const supabase = createClient();
     await supabase.auth.resetPasswordForEmail(forgotEmail, {
-      redirectTo: "https://rbmhr.com/auth/callback?type=recovery",
+      redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
     });
 
     // Always show success — do not reveal whether email exists

--- a/src/app/set-password/SetPasswordClient.tsx
+++ b/src/app/set-password/SetPasswordClient.tsx
@@ -18,6 +18,14 @@ export default function SetPasswordClient() {
   const supabase = createClient();
 
   useEffect(() => {
+    // Check for an already-established session (e.g. after server-side callback redirect)
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        setIsValidSession(true);
+        setIsLoading(false);
+      }
+    });
+
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event) => {


### PR DESCRIPTION
Fixes two root-cause auth bugs:

- `SetPasswordClient`: add `getSession()` on mount so users arriving from server-side callback redirect are recognized as authenticated
- `login`: replace hardcoded `rbmhr.com` redirectTo with `window.location.origin` so password reset emails work on any deployment domain

Closes #41

Generated with [Claude Code](https://claude.ai/code)