### PR TITLE
feat: add Google Sheets carrier roster lookup to HR Tasks page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Google Sheets — carrier enrollment roster
+# GOOGLE_SHEETS_ID: from your sheet URL: docs.google.com/spreadsheets/d/[THIS_PART]/edit
+# GOOGLE_API_KEY: from Google Cloud Console > Credentials (restrict to Sheets API only)
+GOOGLE_SHEETS_ID=your_sheet_id_from_url
+GOOGLE_API_KEY=your_google_api_key

--- a/src/app/api/roster/route.ts
+++ b/src/app/api/roster/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export interface Employee {
+  employeeNumber: string
+  firstName: string
+  lastName: string
+  planType: string
+  plan: string
+}
+
+// In-memory cache (best-effort — resets on cold start)
+let cache: { data: Employee[]; fetchedAt: number } | null = null
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+async function fetchFromSheets(): Promise<Employee[]> {
+  const SHEET_ID = process.env.GOOGLE_SHEETS_ID
+  const API_KEY = process.env.GOOGLE_API_KEY
+  const RANGE = 'Sheet1!A2:E'
+
+  if (!SHEET_ID || !API_KEY) {
+    throw new Error('GOOGLE_SHEETS_ID and GOOGLE_API_KEY environment variables are not set')
+  }
+
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${encodeURIComponent(RANGE)}?key=${API_KEY}`
+  const response = await fetch(url, { cache: 'no-store' })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Google Sheets API error ${response.status}: ${text}`)
+  }
+
+  const data = await response.json()
+  const rows: string[][] = data.values ?? []
+
+  return rows.map((row) => ({
+    employeeNumber: row[0] ?? '',
+    firstName: row[1] ?? '',
+    lastName: row[2] ?? '',
+    planType: row[3] ?? '',
+    plan: row[4] ?? '',
+  }))
+}
+
+export async function GET(request: NextRequest) {
+  const refresh = request.nextUrl.searchParams.get('refresh') === 'true'
+
+  if (refresh) {
+    cache = null
+  }
+
+  const now = Date.now()
+  if (cache && now - cache.fetchedAt < CACHE_TTL) {
+    return NextResponse.json({ employees: cache.data, cached: true })
+  }
+
+  try {
+    const employees = await fetchFromSheets()
+    cache = { data: employees, fetchedAt: now }
+    return NextResponse.json({ employees, cached: false })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch roster'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/app/hr-tasks/HrTasksClient.tsx
+++ b/src/app/hr-tasks/HrTasksClient.tsx
@@ -1,9 +1,43 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect, useCallback } from "react";
 import { updateHrTaskProgress } from "@/app/actions/hr-tasks";
 
 const TOTAL_EMPLOYEES = 719;
+
+interface Employee {
+  employeeNumber: string;
+  firstName: string;
+  lastName: string;
+  planType: string;
+  plan: string;
+}
+
+interface ActionBadge {
+  label: string;
+  color: string;
+  bg: string;
+  border: string;
+}
+
+function getActionBadge(plan: string): ActionBadge {
+  const p = plan.toLowerCase().trim();
+  if (p.includes("select health")) {
+    return { label: "Select Health – No Part III", color: "#1d4ed8", bg: "#eff6ff", border: "#93c5fd" };
+  }
+  if (
+    p.includes("bronze ihc") ||
+    p.includes("bronze non") ||
+    p.includes("gold ihc") ||
+    p.includes("gold non")
+  ) {
+    return { label: "Self-Insured – Part III Required", color: "#991b1b", bg: "#fef2f2", border: "#fca5a5" };
+  }
+  if (p === "mec plan" || p.includes("mec") || p.includes("declined") || p.includes("waived")) {
+    return { label: "No Action Needed", color: "#14532d", bg: "#f0fdf4", border: "#86efac" };
+  }
+  return { label: "Update Required", color: "#92400e", bg: "#fffbeb", border: "#f59e0b" };
+}
 
 interface Props {
   initialElectionCount: number;
@@ -15,7 +49,52 @@ export default function HrTasksClient({ initialElectionCount }: Props) {
   const [isPending, startTransition] = useTransition();
   const [saved, setSaved] = useState(false);
 
+  // Roster state
+  const [roster, setRoster] = useState<Employee[]>([]);
+  const [rosterLoading, setRosterLoading] = useState(true);
+  const [rosterError, setRosterError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+
   const pct = Math.min(100, Math.round((electionCount / TOTAL_EMPLOYEES) * 100));
+
+  const fetchRoster = useCallback(async (refresh = false) => {
+    setRosterLoading(true);
+    setRosterError(null);
+    try {
+      const url = refresh ? "/api/roster?refresh=true" : "/api/roster";
+      const res = await fetch(url);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+      setRoster(data.employees ?? []);
+    } catch (err: unknown) {
+      setRosterError(err instanceof Error ? err.message : "Failed to load roster");
+    } finally {
+      setRosterLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRoster();
+  }, [fetchRoster]);
+
+  const searchResults =
+    searchQuery.trim().length > 0
+      ? roster.filter((emp) => {
+          const q = searchQuery.toLowerCase().trim();
+          return (
+            emp.employeeNumber.toLowerCase().includes(q) ||
+            emp.firstName.toLowerCase().includes(q) ||
+            emp.lastName.toLowerCase().includes(q) ||
+            `${emp.firstName} ${emp.lastName}`.toLowerCase().includes(q)
+          );
+        })
+      : [];
+
+  // Summary stats
+  const noActionCount = roster.filter((e) => getActionBadge(e.plan).label === "No Action Needed").length;
+  const selectHealthCount = roster.filter((e) => getActionBadge(e.plan).label === "Select Health – No Part III").length;
+  const selfInsuredCount = roster.filter((e) => getActionBadge(e.plan).label === "Self-Insured – Part III Required").length;
+  const updateRequiredCount = roster.filter((e) => getActionBadge(e.plan).label === "Update Required").length;
 
   function handleSave() {
     const n = parseInt(inputValue, 10);
@@ -83,6 +162,123 @@ export default function HrTasksClient({ initialElectionCount }: Props) {
           >
             📁 Insurance Benefits &gt; Benefits by Employee
           </span>
+        </div>
+
+        {/* ROSTER SUMMARY PANEL */}
+        <div
+          className="rounded-lg p-4 mb-4"
+          style={{ background: "#f8fafc", border: "1px solid #cbd5e1" }}
+        >
+          <p className="text-sm font-semibold text-gray-700 mb-3">Roster Summary</p>
+          {rosterLoading ? (
+            <p className="text-sm text-gray-500">Loading roster data…</p>
+          ) : rosterError ? (
+            <p className="text-sm" style={{ color: "#991b1b" }}>
+              Unable to load roster: {rosterError}
+            </p>
+          ) : (
+            <div className="grid grid-cols-2 gap-x-8 gap-y-1.5 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Total on roster:</span>
+                <span className="font-semibold text-gray-900">{roster.length}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">No action needed (MEC/Declined):</span>
+                <span className="font-semibold" style={{ color: "#14532d" }}>{noActionCount}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Need updating:</span>
+                <span className="font-semibold" style={{ color: "#92400e" }}>{updateRequiredCount}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Select Health (no Part III):</span>
+                <span className="font-semibold" style={{ color: "#1d4ed8" }}>{selectHealthCount}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Self-insured (Part III required):</span>
+                <span className="font-semibold" style={{ color: "#991b1b" }}>{selfInsuredCount}</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* EMPLOYEE ROSTER LOOKUP PANEL */}
+        <div
+          className="rounded-lg p-4 mb-5"
+          style={{ background: "#ffffff", border: "1px solid #cbd5e1" }}
+        >
+          <p className="text-sm font-semibold text-gray-800 mb-3">Find Employee Plan from Carrier Roster</p>
+
+          {/* Search input */}
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search by employee number, first name, or last name"
+            className="w-full rounded-md border text-sm px-3 py-2 mb-3"
+            style={{ borderColor: "#d1d5db", outline: "none" }}
+            disabled={rosterLoading || !!rosterError}
+          />
+
+          {/* Search results */}
+          {searchQuery.trim().length > 0 && (
+            <div className="space-y-2">
+              {searchResults.length === 0 ? (
+                <p className="text-sm text-gray-500">No employees found matching &quot;{searchQuery}&quot;</p>
+              ) : (
+                searchResults.map((emp) => {
+                  const badge = getActionBadge(emp.plan);
+                  return (
+                    <div
+                      key={emp.employeeNumber}
+                      className="rounded-md p-3"
+                      style={{ background: "#f9fafb", border: "1px solid #e5e7eb" }}
+                    >
+                      <div className="flex items-start justify-between gap-3 flex-wrap">
+                        <div>
+                          <p className="text-sm font-semibold text-gray-900">
+                            {emp.firstName} {emp.lastName}
+                          </p>
+                          <p className="text-xs text-gray-500 mt-0.5">
+                            Employee #{emp.employeeNumber}
+                            {emp.planType ? ` · ${emp.planType}` : ""}
+                          </p>
+                          <p className="text-xs text-gray-700 mt-1">
+                            Plan: <span className="font-medium">{emp.plan || "—"}</span>
+                          </p>
+                        </div>
+                        <span
+                          className="text-xs font-semibold px-2.5 py-1 rounded-full flex-shrink-0"
+                          style={{ color: badge.color, background: badge.bg, border: `1px solid ${badge.border}` }}
+                        >
+                          {badge.label}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+
+          {/* Info box */}
+          <div
+            className="mt-4 rounded-md p-3 text-xs"
+            style={{ background: "#f1f5f9", border: "1px solid #cbd5e1", color: "#475569" }}
+          >
+            Data pulls from the carrier enrollment roster in Google Sheets. If an employee is missing
+            or their plan is wrong, update the Google Sheet first then refresh this page.
+          </div>
+
+          {/* Refresh button */}
+          <button
+            onClick={() => fetchRoster(true)}
+            disabled={rosterLoading}
+            className="mt-3 text-xs font-semibold px-3 py-1.5 rounded-md transition-colors"
+            style={{ background: "#e2e8f0", color: "#334155" }}
+          >
+            {rosterLoading ? "Loading…" : "↺ Refresh Roster Data"}
+          </button>
         </div>
 
         {/* GREEN INFO BOX — You can start NOW */}


### PR DESCRIPTION
Closes #52

Adds Google Sheets carrier enrollment roster lookup to the HR Tasks page:

- /api/roster route fetching Google Sheets API v4 with 5-minute cache
- Roster Summary panel with live counts
- Employee Roster Lookup with search and colour-coded action badges
- Refresh Roster Data button

> ⚠️ Requires GOOGLE_SHEETS_ID and GOOGLE_API_KEY in Vercel environment variables

Generated with [Claude Code](https://claude.ai/code)